### PR TITLE
feat: add changeTicketType behavior setting (#460)

### DIFF
--- a/src/Settings/BehaviorSettings.php
+++ b/src/Settings/BehaviorSettings.php
@@ -26,6 +26,7 @@ class BehaviorSettings
         public int $prioritySwapCount = 1,
         public bool $callTicketByService = false,
         public bool $callTicketOutOfOrder = false,
+        public bool $changeTicketType = true,
     ) {
     }
 }

--- a/src/Settings/UserBehaviorSettings.php
+++ b/src/Settings/UserBehaviorSettings.php
@@ -26,6 +26,7 @@ class UserBehaviorSettings
     public function __construct(
         public ?bool $callTicketByService = null,
         public ?bool $callTicketOutOfOrder = null,
+        public ?bool $changeTicketType = null,
     ) {
     }
 }


### PR DESCRIPTION
## Summary

Adds the `changeTicketType` property to the settings classes as part of novosga/novosga#460 (main PR: novosga/novosga#494).

- `BehaviorSettings`: adds `bool $changeTicketType = true` (backward-compatible default)
- `UserBehaviorSettings`: adds `?bool $changeTicketType = null` (null = inherit global)

Follows the same pattern established by the per-user behavior settings in #9.

## Test plan

- [ ] `BehaviorSettings` instantiated without arguments → `changeTicketType` defaults to `true`
- [ ] `UserBehaviorSettings` instantiated without arguments → `changeTicketType` defaults to `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)