### PR TITLE
chore: upgrade Symfony from 7.1 to 7.4 LTS (#455)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
     "require": {
         "php": ">=8.2",
         "doctrine/orm": "^3.2",
-        "symfony/http-kernel": "7.1.*",
-        "symfony/form": "7.1.*",
+        "symfony/http-kernel": "7.4.*",
+        "symfony/form": "7.4.*",
         "symfony/event-dispatcher-contracts": "^3.5",
-        "symfony/validator": "7.1.*",
-        "symfony/security-core": "7.1.*"
+        "symfony/validator": "7.4.*",
+        "symfony/security-core": "7.4.*"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",


### PR DESCRIPTION
## Summary

Part of novosga/novosga#455 — main PR: novosga/novosga#495.

Bumps all `symfony/*` constraints from `7.1.*` → `7.4.*` in `composer.json`.

## Test plan

- [x] `composer install` resolves cleanly
- [x] `vendor/bin/phpunit` passes
- [x] `vendor/bin/phpstan` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)